### PR TITLE
QGuiApplication::focusObject can be null

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+maliit-framework (0.99.1+git20151118+62bd56b-0ubports2) xenial; urgency=medium
+
+  * Stop client crashing when QGuiApplication::focusObject is null
+
+ -- Dalton Durst <dalton@ubports.com>  Thu, 26 Mar 2020 16:02:50 -0500
+
 maliit-framework (0.99.1+git20151118+62bd56b-0ubports1) xenial; urgency=medium
 
   * Build-depend on qml-module-qtquick2 instead of transitional package
@@ -421,5 +427,3 @@ maliit-framework (0.81.0.1-0) unstable; urgency=low
   * New release
 
  -- Jon Nordby <jonn@openismus.com>  Tue, 06 Sep 2011 12:41:43 +0300
-
-

--- a/debian/patches/0018-focus-object-can-be-null.patch
+++ b/debian/patches/0018-focus-object-can-be-null.patch
@@ -1,0 +1,23 @@
+Index: maliit-framework-0.99.1+git20151118+62bd56b/input-context/minputcontext.cpp
+===================================================================
+--- maliit-framework-0.99.1+git20151118+62bd56b.orig/input-context/minputcontext.cpp	2020-03-26 18:35:00.000000000 -0500
++++ maliit-framework-0.99.1+git20151118+62bd56b/input-context/minputcontext.cpp	2020-03-30 11:41:48.399335549 -0500
+@@ -306,7 +306,7 @@
+         active = true;
+     }
+ 
+-    if (currentFocusAcceptsInput) {
++    if (newFocusWindow && currentFocusAcceptsInput) {
+         updateServerOrientation(newFocusWindow->contentOrientation());
+     }
+ 
+@@ -847,6 +847,9 @@
+     if (!inputMethodAccepted()) {
+         return;
+     }
++    if (!qGuiApp->focusObject()) {
++        return;
++    }
+     if (debug) qDebug() << InputContextName << __PRETTY_FUNCTION__;
+ 
+     QVariantMap extensions = qGuiApp->focusObject()->property("__inputMethodExtensions").toMap();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@ qt_override_server_address
 compose-input-platform-in-maliit.patch
 0016-set-plugin-path-from-environment.patch
 0017-maliit-config-path-environment-variable.patch
+0018-focus-object-can-be-null.patch


### PR DESCRIPTION
In the current implementation of QGuiApplication, ::focusObject() returns null when there is not a focused window. This is a rare occurrence, but it is possible and leads to the Maliit client crashing.

This fixes Unity8 crashing when adding or removing a screen.